### PR TITLE
Erl low volume example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ override.tf.json
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
 .terraform.lock.hcl
+*.tfvars

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ If there is a hard limit on the amount of traffic your backend should receive fo
 ## Put requests in the ERL Penalty Box when a specific condition is met from the origin response
 The origin can have access to different sources of intelligence and data. If a block action is take at the origin, then the block can tell the edge that future requests should be blocked based on a condition such as the client IP.
 
+## Rate Limit on lower volume traffic
+Many misuse and abuse cases are generated from lower volume traffic volumes. A common problem is credential stuffing or credential cracking on a login form. A frequent way to add friction for an attacker is to block an client by IP address, request header, or some other identifier after an excessive number of login attempts. This example uses the request header *rl-key* as the client identifier entry. The snippet named _edge_rate_limiting_low_volume.vcl_ utilizes the [60 second ratecounter bucket](https://developer.fastly.com/reference/vcl/variables/rate-limiting/ratecounter-bucket-60s/) as the value to determine if a request is in violation of the configured allowed rate of requests. The way to configure the request per 60 seconds (aka request per minute or RPM) rate is with the edge dictionary named _login_paths_. You can then see the headers in a response to inspect the decision making. 
+* rl-rate-60 
+* rl-bucket-60
+* rl-delta
+
+Information on these header values can be in the snippet _debug_low_volume_edge_rate_limit.vcl_. In a production setting, you would not want to reflect these values back to an attacker. It is possible to also use the _delta_ parameter with the check_rate VCL function to increment high risk traffic. In this example snippet, you may add the request header *high-risk* with any value to see the concept in action. This type of logic could be useful when you want high risk traffic to hit the upper bound on rate more quickly, such as traffic coming from ToR or other sources with a significant amount of abusive traffic.
+
+
 # How to test
 There are a spectrum of different tools out there to test out the rate limiting functionality. [Siege](https://github.com/JoeDog/siege) is one of my favorite because of how simple it is.
 
@@ -37,3 +46,5 @@ There are a spectrum of different tools out there to test out the rate limiting 
 Other tools like [vegeta](https://github.com/tsenart/vegeta) are highly customizable and highly performant tools.
 
 `echo "GET https://YOUR_DOMAIN_HERE/some/path/123?x-obj-status=206" | vegeta attack -header "vegeta-test:ratelimittest1" -duration=60s  | vegeta report -type=text`
+
+Also, there should be a helpful output for testing after successfully running `terraform apply`.

--- a/main.tf
+++ b/main.tf
@@ -17,19 +17,20 @@ provider "fastly" {
 resource "fastly_service_vcl" "edge-rate-limiting-terraform-service" {
   name = "edge-rate-limiting-terraform"
 
-   domain {
-     name    = var.USER_DOMAIN_NAME
-     comment = "demo for configuring edge rate limiting with terraform"
-    }
-    backend {
-      address = var.USER_DEFAULT_BACKEND_HOSTNAME
-      name = "fastly_origin"
-      port    = 443
-      use_ssl = true
-      ssl_cert_hostname = var.USER_DEFAULT_BACKEND_HOSTNAME
-      ssl_sni_hostname = var.USER_DEFAULT_BACKEND_HOSTNAME
-      override_host = var.USER_DEFAULT_BACKEND_HOSTNAME
-    }
+  domain {
+    name    = var.USER_DOMAIN_NAME
+    comment = "demo for configuring edge rate limiting with terraform"
+  }
+    
+  backend {
+    address = var.USER_DEFAULT_BACKEND_HOSTNAME
+    name = "fastly_origin"
+    port    = 443
+    use_ssl = true
+    ssl_cert_hostname = var.USER_DEFAULT_BACKEND_HOSTNAME
+    ssl_sni_hostname = var.USER_DEFAULT_BACKEND_HOSTNAME
+    override_host = var.USER_DEFAULT_BACKEND_HOSTNAME
+  }
    
     # snippet {
     #   name = "Default Edge Rate Limiting"
@@ -37,6 +38,22 @@ resource "fastly_service_vcl" "edge-rate-limiting-terraform-service" {
     #   type = "init"
     #   priority = 100
     # }
+
+    #### Rate limit with lower volume traffic
+  snippet {
+    name = "Low Volume Login Edge Rate Limiting"
+    content = file("${path.module}/snippets/edge_rate_limiting_low_volume.vcl")
+    type = "init"
+    priority = 90
+  }
+
+    #### Debug Rate limit with lower volume traffic - ONLY USE FOR DEBUGGING SINCE THIS SENDS RATE COUNT INFORMATION BACK TO THE CLIENT
+  snippet {
+    name = "Debug Low Volume Login Edge Rate Limit"
+    content = file("${path.module}/snippets/debug_low_volume_edge_rate_limit.vcl")
+    type = "deliver"
+    priority = 100
+  }
 
     # snippet {
     #   name = "Edge Rate Limiting with URL as key"
@@ -53,21 +70,22 @@ resource "fastly_service_vcl" "edge-rate-limiting-terraform-service" {
     #   priority = 106
     # }
 
-    ##### Rate limit by request header "user-id" - Orange frodo
-    snippet {
-      name = "Edge Rate Limit by user-id request header"
-      content = file("${path.module}/snippets/edge_rate_limiting_request_header.vcl")
-      type = "init"
-      priority = 110
-    }
+  ##### Rate limit by request header "user-id" - Orange frodo
+  snippet {
+    name = "Edge Rate Limit by user-id request header"
+    content = file("${path.module}/snippets/edge_rate_limiting_request_header.vcl")
+    type = "init"
+    priority = 110
+  }
 
-    ##### origin_waf_response
-    snippet {
-      name = "Origin Response Penalty Box"
-      content = file("${path.module}/snippets/origin_response_penalty_box.vcl")
-      type = "init"
-      priority = 130
-    }
+  ##### origin_waf_response
+  snippet {
+    name = "Origin Response Penalty Box"
+    content = file("${path.module}/snippets/origin_response_penalty_box.vcl")
+    type = "init"
+    priority = 130
+  }
+    
 
     ##### Rate limit by URL and group specific URLs together - Advanced case
     # snippet {
@@ -78,19 +96,63 @@ resource "fastly_service_vcl" "edge-rate-limiting-terraform-service" {
     # }
 
     ##### It is necessecary to disable caching for ERL to increment the counter for origin/backend requests
-    snippet {
-      name = "Disable caching"
-      content = file("${path.module}/snippets/disable_caching.vcl")
-      type = "recv"
-      priority = 100
-    }
+  snippet {
+    name = "Disable caching"
+    content = file("${path.module}/snippets/disable_caching.vcl")
+    type = "recv"
+    priority = 100
+  }
+
+  dictionary {
+    name       = "login_paths"
+  }
+
+  dictionary {
+    name       = "login_edge_rate_limit_config"
+  }
 
     force_destroy = true
+}
+
+resource "fastly_service_dictionary_items" "login_paths_dictionary_items" {
+  for_each = {
+  for d in fastly_service_vcl.edge-rate-limiting-terraform-service.dictionary : d.name => d if d.name == "login_paths"
+  }
+  service_id = fastly_service_vcl.edge-rate-limiting-terraform-service.id
+  dictionary_id = each.value.dictionary_id
+
+  items = {
+    "/login": 1,
+    "/auth": 2,
+    "/gateway": 3,
+    "/identity": 4,
+  }
+
+  manage_items = false
+}
+
+resource "fastly_service_dictionary_items" "login_edge_rate_limit_config_dictionary_items" {
+  for_each = {
+  for d in fastly_service_vcl.edge-rate-limiting-terraform-service.dictionary : d.name => d if d.name == "login_edge_rate_limit_config"
+  }
+  service_id = fastly_service_vcl.edge-rate-limiting-terraform-service.id
+  dictionary_id = each.value.dictionary_id
+
+  # rate_limit_rpm_value may not be less than 10
+  items = {
+    "rate_limit_rpm_value": "5",
+    "blocking": "true",
+    "rate_limit_delta_value": "1",
+  }
+  manage_items = true
 }
 
 output "live_laugh_love_edge_rate_limiting" {
   # How to test example
   value = <<tfmultiline
+
+    #### Click the URL to go to the service ####
+    https://cfg.fastly.com/${fastly_service_vcl.edge-rate-limiting-terraform-service.id}
 
     # The following commands are useful for testing.
     
@@ -103,9 +165,14 @@ output "live_laugh_love_edge_rate_limiting" {
     ## Add IP to Rate Limit Penalty box based on origin data
     echo "GET https://${var.USER_DOMAIN_NAME}/some/path/123?x-obj-status=206" | vegeta attack -header "vegeta-test:ratelimittest1" -duration=30s  | vegeta report -type=text
 
-    # While running the test, run the following curl in a seperate adjacent window.
+    # Run the following curl and vegeta commands in a seperate adjacent windows with domain inspector to see the blocks in the Fastly UI.
 
-    watch 'curl -isD - -o /dev/null https://${var.USER_DOMAIN_NAME}/status?x-obj-status=200 -H "Fastly-client-ip: some_ip"'
+    watch -n0.5 'curl -isD - -o /dev/null https://${var.USER_DOMAIN_NAME}/status?x-obj-status=200 -H "fastly-debug:1" -H "user-id:xyz-123"'
+    
+    echo "GET https://${var.USER_DOMAIN_NAME}/status?x-obj-status=200" | vegeta attack -header "user-id:abc-123" -duration=120s  | vegeta report -type=text
+    
+    # Navigate to the Domain Inspector UI
+    https://manage.fastly.com/stats/real-time/services/${fastly_service_vcl.edge-rate-limiting-terraform-service.id}/datacenters/all/domains/
 
   tfmultiline
 }

--- a/main.tf
+++ b/main.tf
@@ -47,14 +47,6 @@ resource "fastly_service_vcl" "edge-rate-limiting-terraform-service" {
     priority = 90
   }
 
-    #### Debug Rate limit with lower volume traffic - ONLY USE FOR DEBUGGING SINCE THIS SENDS RATE COUNT INFORMATION BACK TO THE CLIENT
-  snippet {
-    name = "Debug Low Volume Login Edge Rate Limit"
-    content = file("${path.module}/snippets/debug_low_volume_edge_rate_limit.vcl")
-    type = "deliver"
-    priority = 100
-  }
-
     # snippet {
     #   name = "Edge Rate Limiting with URL as key"
     #   content = file("${path.module}/snippets/edge_rate_limiting_url_key.vcl")
@@ -126,6 +118,7 @@ resource "fastly_service_dictionary_items" "login_paths_dictionary_items" {
     "/auth": 2,
     "/gateway": 3,
     "/identity": 4,
+    "/anything/login": 5,
   }
 
   manage_items = false
@@ -140,9 +133,8 @@ resource "fastly_service_dictionary_items" "login_edge_rate_limit_config_diction
 
   # rate_limit_rpm_value may not be less than 10
   items = {
-    "rate_limit_rpm_value": "5",
+    "rl_low_volume_60_sec_bucket_limit": "5",
     "blocking": "true",
-    "rate_limit_delta_value": "1",
   }
   manage_items = true
 }

--- a/snippets/debug_low_volume_edge_rate_limit.vcl
+++ b/snippets/debug_low_volume_edge_rate_limit.vcl
@@ -2,10 +2,6 @@
 
 if(fastly.ff.visits_this_service == 0 && req.http.fastly-debug){
 
-    set resp.http.rl-check-rate = req.http.rl-check-rate;
-    set resp.http.rl-hit = req.http.Fastly-SEC-RateLimit;
-    set resp.http.rl-rate-60 = ratecounter.rl_low_volume_rc.rate.60s;
-    /* set resp.http.client-ip = req.http.fastly-client-ip; */
     set resp.http.rl-bucket-60 = ratecounter.rl_low_volume_rc.bucket.60s;
     set resp.http.rl-delta = req.http.rl-low-volume-delta;
 }

--- a/snippets/debug_low_volume_edge_rate_limit.vcl
+++ b/snippets/debug_low_volume_edge_rate_limit.vcl
@@ -1,0 +1,13 @@
+# vcl_deliver
+
+if(fastly.ff.visits_this_service == 0 && req.http.fastly-debug){
+
+    set resp.http.rl-check-rate = req.http.rl-check-rate;
+    set resp.http.rl-hit = req.http.Fastly-SEC-RateLimit;
+    set resp.http.rl-rate-60 = ratecounter.rl_low_volume_rc.rate.60s;
+    /* set resp.http.client-ip = req.http.fastly-client-ip; */
+    set resp.http.rl-bucket-60 = ratecounter.rl_low_volume_rc.bucket.60s;
+    set resp.http.rl-delta = req.http.rl-low-volume-delta;
+}
+
+# remove request headers if the request is already cached so as to not log headers

--- a/snippets/debug_low_volume_edge_rate_limit.vcl
+++ b/snippets/debug_low_volume_edge_rate_limit.vcl
@@ -1,9 +1,0 @@
-# vcl_deliver
-
-if(fastly.ff.visits_this_service == 0 && req.http.fastly-debug){
-
-    set resp.http.rl-bucket-60 = ratecounter.rl_low_volume_rc.bucket.60s;
-    set resp.http.rl-delta = req.http.rl-low-volume-delta;
-}
-
-# remove request headers if the request is already cached so as to not log headers

--- a/snippets/edge_rate_limiting_low_volume.vcl
+++ b/snippets/edge_rate_limiting_low_volume.vcl
@@ -1,0 +1,109 @@
+
+# Snippet rate-limiter-v1-low_volume-init
+penaltybox rl_low_volume_pb {}
+ratecounter rl_low_volume_rc {}
+table rl_low_volume_methods {
+  "GET": "true",
+  "PUT": "true",
+  "TRACE": "true",
+  "POST": "true",
+  "HEAD": "true",
+  "DELETE": "true",
+  "PATCH": "true",
+  "OPTIONS": "true",
+}
+
+# use a seperate table for the ERL tuning
+
+sub rl_low_volume_process {
+  declare local var.rl_low_volume_window INTEGER;
+  declare local var.rl_low_volume_limit INTEGER;
+  declare local var.rl_low_volume_ttl TIME;
+  declare local var.rl_low_volume_entry STRING;
+  declare local var.rl_low_volume_delta INTEGER;
+  declare local var.rl_low_volume_60_sec_bucket_limit INTEGER;
+
+  set var.rl_low_volume_window = 60;
+  set var.rl_low_volume_limit = 10;
+
+  if (std.atoi(table.lookup(login_edge_rate_limit_config, "rate_limit_delta_value")) > 0) {
+    set var.rl_low_volume_delta = std.atoi(table.lookup(login_edge_rate_limit_config, "rate_limit_delta_value"));
+  } else {
+    set var.rl_low_volume_delta = 60;
+  }
+  set req.http.rl-low-volume-delta = var.rl_low_volume_delta;
+
+  # ERL's check_rate requires an integer greater than 9
+  if (std.atoi(table.lookup(login_edge_rate_limit_config, "rate_limit_rpm_value")) > 1) {
+    set var.rl_low_volume_60_sec_bucket_limit = std.atoi(table.lookup(login_edge_rate_limit_config, "rate_limit_rpm_value"));
+  } else {
+    set var.rl_low_volume_60_sec_bucket_limit = 10;
+  }
+
+  # 10 is the lowest value that may be used for the check_rate function, but the approximate aggregate counts for a window are available in the rate counter buckets.
+  # https://developer.fastly.com/reference/vcl/variables/rate-limiting/
+
+  set var.rl_low_volume_ttl = 2m;
+  /* set var.rl_low_volume_entry = client.ip; */
+  set var.rl_low_volume_entry = req.http.rl-key;
+  if (req.restarts == 0 && fastly.ff.visits_this_service == 0
+      && table.contains(rl_low_volume_methods, req.method)
+      && table.contains(login_paths, std.tolower(req.url.path))
+      && std.strlen(var.rl_low_volume_entry) > 0
+      && table.lookup(login_edge_rate_limit_config, "blocking") == "true"
+      ) {
+    # set req.http.rl-check-rate = "true"; # use for debugging
+    if (req.http.high-risk) {
+      if (ratelimit.check_rate(var.rl_low_volume_entry
+        , rl_low_volume_rc
+        , 3 # Using higher delta value for higher risk requests
+        , var.rl_low_volume_window
+        , var.rl_low_volume_limit
+        , rl_low_volume_pb
+        , var.rl_low_volume_ttl)
+        ) {
+      # set req.http.Fastly-SEC-RateLimit = "true"; # use for debugging
+      set req.http.Fastly-login-erl-limit = table.lookup(login_edge_rate_limit_config, "login_edge_rate_limit_config");
+      error 829 "Rate limiter: Too many requests for low_volume";
+    } 
+    }
+    if (ratelimit.check_rate(var.rl_low_volume_entry
+        , rl_low_volume_rc
+        , var.rl_low_volume_delta
+        , var.rl_low_volume_window
+        , var.rl_low_volume_limit
+        , rl_low_volume_pb
+        , var.rl_low_volume_ttl)
+        ) {
+      /* set req.http.Fastly-SEC-RateLimit = "true"; # Use for debugging */
+      set req.http.Fastly-login-erl-limit = table.lookup(login_edge_rate_limit_config, "login_edge_rate_limit_config");
+      error 829 "Rate limiter: Too many requests for low_volume";
+    } 
+    if (ratecounter.rl_low_volume_rc.bucket.60s > var.rl_low_volume_60_sec_bucket_limit) {
+      /* set req.http.Fastly-SEC-RateLimit = "true"; # Use for debugging */
+      set req.http.Fastly-login-erl-limit = table.lookup(login_edge_rate_limit_config, "login_edge_rate_limit_config");
+      error 829 "Rate limiter: Too many requests for low_volume";
+    }
+  }
+}
+
+sub vcl_miss {
+    # Snippet rate-limiter-v1-low_volume-miss
+    call rl_low_volume_process;
+}
+
+sub vcl_pass {
+    # Snippet rate-limiter-v1-low_volume-pass
+    call rl_low_volume_process;
+}
+
+sub vcl_error {
+    # Snippet rate-limiter-v1-low_volume-error
+    if (obj.status == 829 && obj.response == "Rate limiter: Too many requests for low_volume") {
+        set obj.status = 429;
+        set obj.response = "Too Many Requests";
+        set obj.http.Content-Type = "text/html";
+        synthetic.base64 "PGh0bWw+Cgk8aGVhZD4KCQk8dGl0bGU+VG9vIE1hbnkgUmVxdWVzdHM8L3RpdGxlPgoJPC9oZWFkPgoJPGJvZHk+CgkJPHA+VG9vIE1hbnkgUmVxdWVzdHMgdG8gdGhlIHNpdGU8L3A+Cgk8L2JvZHk+CjwvaHRtbD4=";
+        return(deliver);
+    }
+}

--- a/snippets/edge_rate_limiting_low_volume.vcl
+++ b/snippets/edge_rate_limiting_low_volume.vcl
@@ -16,72 +16,47 @@ table rl_low_volume_methods {
 # use a seperate table for the ERL tuning
 
 sub rl_low_volume_process {
-  declare local var.rl_low_volume_window INTEGER;
+  /* declare local var.rl_low_volume_window INTEGER; */
   declare local var.rl_low_volume_limit INTEGER;
-  declare local var.rl_low_volume_ttl TIME;
   declare local var.rl_low_volume_entry STRING;
   declare local var.rl_low_volume_delta INTEGER;
   declare local var.rl_low_volume_60_sec_bucket_limit INTEGER;
 
-  set var.rl_low_volume_window = 60;
-  set var.rl_low_volume_limit = 10;
-
-  if (std.atoi(table.lookup(login_edge_rate_limit_config, "rate_limit_delta_value")) > 0) {
-    set var.rl_low_volume_delta = std.atoi(table.lookup(login_edge_rate_limit_config, "rate_limit_delta_value"));
+  # Check if the entry is greater than 0
+  /* if (table.lookup(login_edge_rate_limit_config, "rl_low_volume_60_sec_bucket_limit") > 0) { */
+  if (std.atoi(table.lookup(login_edge_rate_limit_config, "rl_low_volume_60_sec_bucket_limit")) > 0) {
+    set var.rl_low_volume_60_sec_bucket_limit = std.atoi(table.lookup(login_edge_rate_limit_config, "rl_low_volume_60_sec_bucket_limit"));
   } else {
-    set var.rl_low_volume_delta = 60;
+    set var.rl_low_volume_60_sec_bucket_limit = 10 ;
   }
+
+  set req.http.rl-limit = var.rl_low_volume_60_sec_bucket_limit;
+
+  # Set for debugging
   set req.http.rl-low-volume-delta = var.rl_low_volume_delta;
 
-  # ERL's check_rate requires an integer greater than 9
-  if (std.atoi(table.lookup(login_edge_rate_limit_config, "rate_limit_rpm_value")) > 1) {
-    set var.rl_low_volume_60_sec_bucket_limit = std.atoi(table.lookup(login_edge_rate_limit_config, "rate_limit_rpm_value"));
-  } else {
-    set var.rl_low_volume_60_sec_bucket_limit = 10;
-  }
-
-  # 10 is the lowest value that may be used for the check_rate function, but the approximate aggregate counts for a window are available in the rate counter buckets.
-  # https://developer.fastly.com/reference/vcl/variables/rate-limiting/
-
-  set var.rl_low_volume_ttl = 2m;
-  /* set var.rl_low_volume_entry = client.ip; */
   set var.rl_low_volume_entry = req.http.rl-key;
   if (req.restarts == 0 && fastly.ff.visits_this_service == 0
       && table.contains(rl_low_volume_methods, req.method)
       && table.contains(login_paths, std.tolower(req.url.path))
       && std.strlen(var.rl_low_volume_entry) > 0
-      && table.lookup(login_edge_rate_limit_config, "blocking") == "true"
       ) {
-    # set req.http.rl-check-rate = "true"; # use for debugging
-    if (req.http.high-risk) {
-      if (ratelimit.check_rate(var.rl_low_volume_entry
-        , rl_low_volume_rc
-        , 3 # Using higher delta value for higher risk requests
-        , var.rl_low_volume_window
-        , var.rl_low_volume_limit
-        , rl_low_volume_pb
-        , var.rl_low_volume_ttl)
-        ) {
-      # set req.http.Fastly-SEC-RateLimit = "true"; # use for debugging
-      set req.http.Fastly-login-erl-limit = table.lookup(login_edge_rate_limit_config, "login_edge_rate_limit_config");
-      error 829 "Rate limiter: Too many requests for low_volume";
-    } 
+
+    # https://developer.fastly.com/reference/vcl/functions/rate-limiting/ratelimit-ratecounter-increment/
+    # high risk
+    declare local var.rl_last_60_sec_bucket INTEGER;
+    if (req.http.high-risk || client.geo.proxy_description ~ "^tor-")  {
+      set var.rl_last_60_sec_bucket = ratelimit.ratecounter_increment(rl_low_volume_rc, var.rl_low_volume_entry, 3);
+    } else {
+      # not high risk
+      set var.rl_last_60_sec_bucket = ratelimit.ratecounter_increment(rl_low_volume_rc, var.rl_low_volume_entry, 1);
     }
-    if (ratelimit.check_rate(var.rl_low_volume_entry
-        , rl_low_volume_rc
-        , var.rl_low_volume_delta
-        , var.rl_low_volume_window
-        , var.rl_low_volume_limit
-        , rl_low_volume_pb
-        , var.rl_low_volume_ttl)
-        ) {
+   
+    if (ratecounter.rl_low_volume_rc.bucket.60s > var.rl_low_volume_60_sec_bucket_limit
+      && table.lookup(login_edge_rate_limit_config, "blocking") == "true") {
       /* set req.http.Fastly-SEC-RateLimit = "true"; # Use for debugging */
-      set req.http.Fastly-login-erl-limit = table.lookup(login_edge_rate_limit_config, "login_edge_rate_limit_config");
-      error 829 "Rate limiter: Too many requests for low_volume";
-    } 
-    if (ratecounter.rl_low_volume_rc.bucket.60s > var.rl_low_volume_60_sec_bucket_limit) {
-      /* set req.http.Fastly-SEC-RateLimit = "true"; # Use for debugging */
-      set req.http.Fastly-login-erl-limit = table.lookup(login_edge_rate_limit_config, "login_edge_rate_limit_config");
+      /* set req.http.Fastly-erl-60-sec-bucket = ratecounter.rl_low_volume_rc.bucket.60s;  */
+      /* set req.http.Fastly-login-erl-limit = table.lookup(login_edge_rate_limit_config, "login_edge_rate_limit_config"); */
       error 829 "Rate limiter: Too many requests for low_volume";
     }
   }
@@ -97,13 +72,22 @@ sub vcl_pass {
     call rl_low_volume_process;
 }
 
+#### Debug Rate limit with lower volume traffic - ONLY USE FOR DEBUGGING SINCE THIS SENDS RATE COUNT INFORMATION BACK TO THE CLIENT
+sub vcl_deliver {
+  if(fastly.ff.visits_this_service == 0 && req.http.fastly-debug){
+    set resp.http.rl-limit = req.http.rl-limit;
+    set resp.http.rl-bucket-60 = ratecounter.rl_low_volume_rc.bucket.60s;
+    set resp.http.rl-delta = req.http.rl-low-volume-delta;
+  }  
+}
+
 sub vcl_error {
     # Snippet rate-limiter-v1-low_volume-error
     if (obj.status == 829 && obj.response == "Rate limiter: Too many requests for low_volume") {
         set obj.status = 429;
         set obj.response = "Too Many Requests";
         set obj.http.Content-Type = "text/html";
-        synthetic.base64 "PGh0bWw+Cgk8aGVhZD4KCQk8dGl0bGU+VG9vIE1hbnkgUmVxdWVzdHM8L3RpdGxlPgoJPC9oZWFkPgoJPGJvZHk+CgkJPHA+VG9vIE1hbnkgUmVxdWVzdHMgdG8gdGhlIHNpdGU8L3A+Cgk8L2JvZHk+CjwvaHRtbD4=";
+        synthetic.base64 "PGh0bWw+CiAgICAgICAgPGhlYWQ+CiAgICAgICAgICAgICAgICA8dGl0bGU+VG9vIE1hbnkgUmVxdWVzdHM8L3RpdGxlPgogICAgICAgIDwvaGVhZD4KICAgICAgICA8Ym9keT4KICAgICAgICAgICAgICAgIDxwPlRvbyBNYW55IFJlcXVlc3RzIHRvIHRoZSBzaXRlLiBMViBFUkw8L3A+CiAgICAgICAgPC9ib2R5Pgo8L2h0bWw+";
         return(deliver);
     }
 }

--- a/snippets/edge_rate_limiting_request_header.vcl
+++ b/snippets/edge_rate_limiting_request_header.vcl
@@ -19,7 +19,7 @@ sub rl_orange_frodo_process {
   declare local var.rl_orange_frodo_ttl TIME;
   declare local var.rl_orange_frodo_entry STRING;
   set var.rl_orange_frodo_limit = 10;
-  set var.rl_orange_frodo_window = 60;
+  set var.rl_orange_frodo_window = 10;
   set var.rl_orange_frodo_ttl = 4m;
   
   # Use the request header user-id for the rate limit key

--- a/snippets/origin_response_penalty_box.vcl
+++ b/snippets/origin_response_penalty_box.vcl
@@ -37,13 +37,13 @@ sub vcl_fetch {
 }
 ##### End check backend response status code
 
-# Start useful troubleshooting based on the response
-sub vcl_deliver {
+# Useful troubleshooting based on the response - Start
+/* sub vcl_deliver {
   if (req.http.fastly-debug == "1"){
     set resp.http.X-ERL-PenaltyBox-has = ratelimit.penaltybox_has(rl_origin_waf_response_pb, client.ip);
   }
-}
-# End useful troubleshooting based on the response
+} */
+# Useful troubleshooting based on the response - End
 
 sub vcl_error {
     # Snippet rate-limiter-v1-origin_waf_response-error-error : 100

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "FASTLY_API_KEY" {
 variable "USER_DOMAIN_NAME" {
   type = string
   description = "Frontend domain for your service."
-  default = "YOUR_DOMAIN_HERE"
+  # default = "YOUR_DOMAIN_HERE.global.ssl.fastly.net"
 }
 
 variable "USER_DEFAULT_BACKEND_HOSTNAME" {


### PR DESCRIPTION
Includes an example for using edge rate limiting primitives for more abuse focused use cases such as credential stuffing.